### PR TITLE
Only install git submodules for .config directory

### DIFF
--- a/install.zsh
+++ b/install.zsh
@@ -46,9 +46,7 @@ main() {
     echo "🚀 Starting dotfiles installation"
 
     echo "📦 Initializing and updating git submodules"
-    git submodule update --init --recursive
-    cd "$DOTFILES_DIR"
-    git submodule update --init --recursive
+    git -C "$DOTFILES_DIR" submodule update --init --recursive
     echo "✅ Git submodules initialised"
 
     if [[ ! -d "$HOME/.config" ]]; then


### PR DESCRIPTION
- A redundant `git submodule update --init --recursive` was in the script, which would have updated submodules for the users current directory.
- Also, pass the directory into the update command so no `cd` is needed, as this modifies the navigation history for the user